### PR TITLE
Add rebar3 support

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,2 @@
+{pre_hooks, [{compile, "make app"}]}.
+


### PR DESCRIPTION
This patch adds a `rebar.config` file to call the `Makefile` for code
generation before compiling. This allows the library to work as a
dependency in rebar projects.
