### PR TITLE
generate union reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.bak
+*.plt
 *.d
 /ebin
 include/kpro.hrl

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = kafka_protocol
 PROJECT_DESCRIPTION = Kafka protocol erlang library
-PROJECT_VERSION = 0.3.1
+PROJECT_VERSION = 0.3.2
 
 COVER = true
 

--- a/priv/kpro_gen.escript
+++ b/priv/kpro_gen.escript
@@ -48,8 +48,10 @@ parse(TokensList) ->
 to_records(Defs) ->
   lists:flatten(lists:map(fun records/1, Defs)).
 
-gname(Name) ->
-  list_to_atom("kpro_" ++ string:strip(atom_to_list(Name), both, $')).
+gname(Name) when is_atom(Name) ->
+  gname(atom_to_list(Name));
+gname(NameStr) when is_list(NameStr) ->
+  list_to_atom("kpro_" ++ string:strip(NameStr, both, $')).
 
 records(Def) -> records(Def, Def).
 
@@ -66,7 +68,7 @@ fields(Fields, Def) ->
             end, Fields).
 
 field_name(Name) when is_atom(Name) ->
-  lower_case_leading(Name);
+  lowercase_leading(Name);
 field_name({array, Name}) ->
   %% for array fields, append a _L suffix to the name
   list_to_atom(atom_to_list(field_name(Name)) ++ "_L").
@@ -127,36 +129,49 @@ gen_records([Rec | Rest]) ->
   [gen_record(Rec), gen_records(Rest)].
 
 gen_record({Name, Fields}) ->
+  {FieldLines, TypeRefs} = gen_record_fields(Fields, [], []),
   ["-record(", atom_to_list(Name), ",\n",
    "        { ",
-              infix(gen_record_fields(Fields), "        , "),
-   "        }).\n\n"
+              infix(FieldLines, "        , "),
+   "        }).\n\n",
+   TypeRefs
   ].
 
 %% change the first char to lower case
-lower_case_leading(Name) ->
+lowercase_leading(Name) ->
   [H | T] = atom_to_list(Name),
   list_to_atom([H + ($a - $A) | T]).
 
-gen_record_fields([]) ->
-  [];
-gen_record_fields([{Name, Type} | Fields]) ->
-  FieldName = atom_to_list(Name),
-  [ [ FieldName, " :: "
-    , case Type of
-        {one_of, Refs} -> gen_union_type(Refs, length(FieldName)+12);
-        _              -> gen_field_type(list_to_atom(FieldName), Type)
-      end
-    , "\n"
-    ]
-  | gen_record_fields(Fields)
-  ].
+uppercase_leading(Name) ->
+  [H | T] = atom_to_list(Name),
+  [H - ($a - $A) | T].
 
-gen_union_type(Refs, Width) ->
+gen_record_fields([], FieldLines, TypeRefs) ->
+  {lists:reverse(FieldLines), TypeRefs};
+gen_record_fields([{Name, Type} | Fields], FieldLines, TypeRefs0) ->
+  FieldName = atom_to_list(Name),
+  {FieldType, TypeRefs} =
+    case Type of
+      {one_of, Refs} ->
+        gen_union_type(Name, Refs, TypeRefs0);
+      _ ->
+        {gen_field_type(list_to_atom(FieldName), Type), TypeRefs0}
+    end,
+  FieldLine = iolist_to_binary([ FieldName, " :: ", FieldType, "\n" ]),
+  gen_record_fields(Fields, [FieldLine | FieldLines], TypeRefs).
+
+gen_union_type(FieldName, TypeRefs, IoDataAcc) ->
+  RefTypeNameStr = atom_to_list(gname(uppercase_leading(FieldName))),
+  Width = length(RefTypeNameStr) + length("-type  :: "),
   Sep = "\n" ++ lists:duplicate(Width, $\s) ++ "| ",
-  infix(lists:map(fun(Name) ->
-                    atom_to_list(Name) ++ "()"
-                  end, Refs), Sep).
+  { RefTypeNameStr ++ "()"
+  , [ IoDataAcc
+    , "-type ", RefTypeNameStr, "() :: "
+    , infix(lists:map(fun(Name) ->
+                        atom_to_list(Name) ++ "()"
+                      end, TypeRefs), Sep)
+    , ".\n\n"
+    ]}.
 
 %% generate special pre-defined types.
 gen_field_type(errorCode, _)     -> "error_code()";

--- a/priv/kpro_gen.escript
+++ b/priv/kpro_gen.escript
@@ -118,6 +118,10 @@ gen_header_file(Records) ->
   ok = file:write_file(Filename, IoData).
 
 gen_types([]) -> [];
+gen_types([{kpro_Message, _Fields} | Rest]) ->
+  %% a special clause for incomplete message
+  ["\n-type kpro_Message() :: incomplete_message | #kpro_Message{}.",
+   gen_types(Rest)];
 gen_types([{Name, _Fields} | Rest]) ->
   RecName = atom_to_list(Name),
   [ bin(["\n-type ", RecName, "() :: #", RecName, "{}."])
@@ -174,7 +178,11 @@ gen_union_type(FieldName, TypeRefs, IoDataAcc) ->
     ]}.
 
 %% generate special pre-defined types.
+%% all 'errorCode' fields should have error_code() spec
+%% use 'any()' spec for all embeded 'bytes' fields
 gen_field_type(errorCode, _)     -> "error_code()";
+gen_field_type(protocolMetadata, bytes) -> "any()";
+gen_field_type(memberAssignment, bytes) -> "any()";
 gen_field_type(_FieldName, Type) -> gen_field_type(Type).
 
 gen_field_type(int8)   -> "int8()";

--- a/src/kafka_protocol.app.src
+++ b/src/kafka_protocol.app.src
@@ -1,6 +1,6 @@
 {application,kafka_protocol,
              [{description,"Kafka protocol erlang library"},
-              {vsn,"0.3.1"},
+              {vsn,"0.3.2"},
               {registered,[]},
               {applications,[kernel,stdlib]},
               {env,[]},

--- a/src/kpro.erl
+++ b/src/kpro.erl
@@ -121,7 +121,7 @@ next_corr_id(CorrId)       -> CorrId + 1.
 %% @doc Parse binary stream received from kafka broker.
 %%      Return a list of kpro_Response() and the remaining bytes.
 %% @end
--spec decode_response(binary()) -> {kpro_Response(), binary()}.
+-spec decode_response(binary()) -> {[kpro_Response()], binary()}.
 decode_response(Bin) ->
   decode_response(Bin, []).
 
@@ -134,22 +134,7 @@ decode_response(Bin, Acc) ->
   end.
 
 %% @doc help function to encode kpro_XxxRequest into kafka wire format.
--spec encode_request(client_id(), corr_id(), RequestMessage) -> iodata()
-        when RequestMessage:: kpro_ProduceRequest()
-                            | kpro_FetchRequest()
-                            | kpro_OffsetRequest()
-                            | kpro_MetadataRequest()
-                            | kpro_OffsetCommitRequestV0()
-                            | kpro_OffsetCommitRequestV1()
-                            | kpro_OffsetCommitRequestV2()
-                            | kpro_OffsetFetchRequest()
-                            | kpro_GroupCoordinatorRequest()
-                            | kpro_JoinGroupRequest()
-                            | kpro_HeartbeatRequest()
-                            | kpro_LeaveGroupRequest()
-                            | kpro_SyncGroupRequest()
-                            | kpro_DescribeGroupsRequest()
-                            | kpro_ListGroupsRequest().
+-spec encode_request(client_id(), corr_id(), kpro_RequestMessage()) -> iodata().
 encode_request(ClientId, CorrId, Request) ->
   R = #kpro_Request{ correlationId  = CorrId
                    , clientId       = ClientId


### PR DESCRIPTION
instead of

```
-record(kpro_Request, { .... requestMessage :: kpro_ProduceRequest() | kpro_FetchRequest()...}).
```

now it's

```
-record(kpro_Request, {... requestMessage :: kpro_RequestMessage()}).
-type kpro_RequestMessage() :: kpro_ProduceRequest() | kpro_FetchRequest()...
```
