### PR TITLE
fix rebar pre_hook to only deal with generated code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = kafka_protocol
 PROJECT_DESCRIPTION = Kafka protocol erlang library
-PROJECT_VERSION = 0.7.4
+PROJECT_VERSION = 0.7.5
 
 EUNIT_OPTS = verbose
 ERLC_OPTS = -Werror +warn_unused_vars +warn_shadow_vars +warn_unused_import +warn_obsolete_guard +debug_info

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,5 @@
 {deps, [{snappyer, "1.1.3-1.0.4"}]}.
-{pre_hooks, [{compile, "make app"}]}.
+{pre_hooks, [ {compile, "make gen-code"}
+            , {clean, "make gen-clean"}
+            ]}.
 

--- a/src/kafka_protocol.app.src
+++ b/src/kafka_protocol.app.src
@@ -1,6 +1,6 @@
 {application,kafka_protocol,
              [{description,"Kafka protocol erlang library"},
-              {vsn,"0.7.4"},
+              {vsn,"0.7.5"},
               {registered,[]},
               {applications,[kernel,stdlib]},
               {env,[]},


### PR DESCRIPTION
`make app` will download and compile dependency in `deps` directly by erlang.mk.