### PR TITLE
Remove escript boot parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = kafka_protocol
 PROJECT_DESCRIPTION = Kafka protocol erlang library
-PROJECT_VERSION = 0.9.1
+PROJECT_VERSION = 0.9.2
 
 EUNIT_OPTS = verbose
 ERLC_OPTS = -Werror +warn_unused_vars +warn_shadow_vars +warn_unused_import +warn_obsolete_guard +debug_info

--- a/priv/kpro_gen.escript
+++ b/priv/kpro_gen.escript
@@ -1,6 +1,5 @@
 #!/usr/bin/env escript
 %% -*- erlang -*-
-%%! -smp enable -sname kpro_gen
 
 %%%
 %%%   Copyright (c) 2014-2016, Klarna AB

--- a/src/kafka_protocol.app.src
+++ b/src/kafka_protocol.app.src
@@ -1,6 +1,6 @@
 {application,kafka_protocol,
              [{description,"Kafka protocol erlang library"},
-              {vsn,"0.9.1"},
+              {vsn,"0.9.2"},
               {registered,[]},
               {applications,[kernel,stdlib,snappyer]},
               {env,[]},


### PR DESCRIPTION
To avoid node name clashing when two projects built at the same time.