### PR TITLE
Add kpro:send/2.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -44,4 +44,6 @@
   - Update snappyer and crc32cer to support configurable nif so file lookup location
 * 2.1.2
   - Bump crc32cer to 0.1.3 to support alpine/busybox build
+* 2.2.0
+  - Add truely async send API `kpro:send/2`
 

--- a/src/kafka_protocol.app.src
+++ b/src/kafka_protocol.app.src
@@ -1,6 +1,6 @@
 {application,kafka_protocol,
              [{description,"Kafka protocol library for Erlang/Elixir"},
-              {vsn,"2.1.2"},
+              {vsn,"2.2.0"},
               {registered,[]},
               {applications,[kernel,stdlib,ssl,snappyer,crc32cer]},
               {env,[]},

--- a/src/kpro.erl
+++ b/src/kpro.erl
@@ -36,6 +36,7 @@
 %% Primitive RPCs
 -export([ request_sync/3
         , request_async/2
+        , send/2
         ]).
 
 %% Transactional RPCs
@@ -317,9 +318,16 @@ request_sync(ConnectionPid, Request, Timeout) ->
 %% The message to expect should have spec `{msg, connection(), #kpro_rsp{}}'
 %% where `#kpro_rsp.ref' matches the sent `Request#kpro_req.ref'.
 %% When it is a produce request with `required_acks=0', there will be no reply.
--spec request_async(pid(), req()) -> ok | {error, any()}.
+-spec request_async(connection(), req()) -> ok | {error, any()}.
 request_async(ConnectionPid, Request) ->
   kpro_connection:request_async(ConnectionPid, Request).
+
+%% @doc Same as @link request_async/2.
+%% Only that the message towards connection process is a cast (not a call).
+%% Always return 'ok'.
+-spec send(connection(), req()) -> ok.
+send(ConnectionPid, Request) when is_pid(ConnectionPid) ->
+  kpro_connection:send(ConnectionPid, Request).
 
 %% @doc Connect to the given endpoint.
 %% NOTE: Connection process is linked to caller unless `nolink => true'

--- a/src/kpro_connection.erl
+++ b/src/kpro_connection.erl
@@ -105,7 +105,7 @@ start(Host, Port, Config) ->
 %% Always return 'ok'.
 -spec send(connection(), kpro:req()) -> ok.
 send(Pid, Request) ->
-  erlang:send(Pid, {{self(), no_reply}, {send, Request}}),
+  erlang:send(Pid, {{self(), noreply}, {send, Request}}),
   ok.
 
 %% @doc Send a request. Caller should expect to receive a response
@@ -323,10 +323,11 @@ call(Pid, Request) ->
       {error, {connection_down, Reason}}
   end.
 
-maybe_reply({To, Ref}, Reply) when is_reference(Ref) ->
-  _ = erlang:send(To, {Ref, Reply}),
+-spec maybe_reply({pid(), reference() | noreply}, term()) -> ok.
+maybe_reply({_, noreply}, _) ->
   ok;
-maybe_reply(_, _) ->
+maybe_reply({To, Ref}, Reply) ->
+  _ = erlang:send(To, {Ref, Reply}),
   ok.
 
 loop(#state{} = State, Debug) ->


### PR DESCRIPTION
For the cases in which caller link/monitor connection and
collect requests for retry when connection down,
there is no need to make blocked call to connection process.