### PR TITLE
Add missing type exports and fix some specs

### DIFF
--- a/src/kpro.erl
+++ b/src/kpro.erl
@@ -102,6 +102,7 @@
              , key/0
              , magic/0
              , message/0
+             , msg_input/0
              , msg_ts/0
              , offset/0
              , offsets_to_commit/0
@@ -121,6 +122,7 @@
              , stack/0
              , str/0
              , struct/0
+             , struct_schema/0
              , timestamp_type/0
              , transactional_id/0
              , txn_ctx/0

--- a/src/kpro_lib.erl
+++ b/src/kpro_lib.erl
@@ -203,7 +203,7 @@ copy_bytes(Size, Bin) ->
   <<Bytes:Size/binary, Rest/binary>> = Bin,
   {binary:copy(Bytes), Rest}.
 
--spec get_ts_type(byte(), byte()) -> kpro:ts_type().
+-spec get_ts_type(byte(), byte()) -> kpro:timestamp_type().
 get_ts_type(0, _) -> undefined;
 get_ts_type(_, A) when ?KPRO_IS_CREATE_TS(A) -> create;
 get_ts_type(_, A) when ?KPRO_IS_APPEND_TS(A) -> append.
@@ -249,7 +249,7 @@ find(_Field, Other) ->
   erlang:error({not_struct, Other}).
 
 %% @doc Find struct field value, return `Default' if the field is not found.
--spec find(kpro:filed_name(), kpro:struct(), kpro:field_value()) ->
+-spec find(kpro:field_name(), kpro:struct(), kpro:field_value()) ->
         kpro:field_value().
 find(Field, Struct, Default) ->
   try


### PR DESCRIPTION
The exported types are used in other modules in module-prefixed form, so they should be exported.
Now there are no dialyzer warnings when running with "unknown" option.