### PR TITLE
Add server_name_indication when needed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -53,5 +53,5 @@
 * 2.2.4
   - Fix type specs (PR #48, by Piotr Bober)
 * 2.2.5
-  - Add `{server_name_indication, Host}` when `{verify_peer, true}` is
+  - Add `{server_name_indication, Host}` when `{verify, verify_peer}` is
     used. This is necessary for OTP >= 20.x.

--- a/changelog.md
+++ b/changelog.md
@@ -52,3 +52,6 @@
   - Gotten rid of OS native timestamps
 * 2.2.4
   - Fix type specs (PR #48, by Piotr Bober)
+* 2.2.5
+  - Add `{server_name_indication, Host}` when `{verify_peer, true}` is
+    used. This is necessary for OTP >= 20.x.

--- a/src/kafka_protocol.app.src
+++ b/src/kafka_protocol.app.src
@@ -1,6 +1,6 @@
 {application,kafka_protocol,
              [{description,"Kafka protocol library for Erlang/Elixir"},
-              {vsn,"2.2.4"},
+              {vsn,"2.2.5"},
               {registered,[]},
               {applications,[kernel,stdlib,ssl,snappyer,crc32cer]},
               {env,[]},

--- a/src/kpro_connection.erl
+++ b/src/kpro_connection.erl
@@ -276,10 +276,10 @@ get_tcp_mod(_)                -> gen_tcp.
 %% (otherwise the IP will be used, which is almost certainly
 %% incorrect).
 insert_server_name_indication(SslOpts, Host) when is_list(SslOpts) ->
-  case proplists:get_value(verify_peer, SslOpts) of
-    true ->
+  case proplists:get_value(verify, SslOpts) of
+    verify_peer ->
       [{server_name_indication, Host}|SslOpts];
-    undefined ->
+    _ ->
       SslOpts
   end;
 insert_server_name_indication(SslOpts, _) ->

--- a/src/kpro_connection.erl
+++ b/src/kpro_connection.erl
@@ -275,15 +275,13 @@ get_tcp_mod(_)                -> gen_tcp.
 %% ensure that peer verification is done against the correct host name
 %% (otherwise the IP will be used, which is almost certainly
 %% incorrect).
-insert_server_name_indication(SslOpts, Host) when is_list(SslOpts) ->
+insert_server_name_indication(SslOpts, Host) ->
   case proplists:get_value(verify, SslOpts) of
     verify_peer ->
       [{server_name_indication, Host}|SslOpts];
     _ ->
       SslOpts
-  end;
-insert_server_name_indication(SslOpts, _) ->
-  SslOpts.
+  end.
 
 maybe_upgrade_to_ssl(Sock, _Mod = ssl, SslOpts0, Host, Timeout) ->
   SslOpts = case SslOpts0 of

--- a/src/kpro_connection.erl
+++ b/src/kpro_connection.erl
@@ -270,7 +270,7 @@ get_tcp_mod(_SslOpts = true)  -> ssl;
 get_tcp_mod(_SslOpts = [_|_]) -> ssl;
 get_tcp_mod(_)                -> gen_tcp.
 
-%% If SslOpts contains {verify_peer, true}, we insert
+%% If SslOpts contains {verify, verify_peer}, we insert
 %% {server_name_indication, Host}. This is necessary as of OTP 20, to
 %% ensure that peer verification is done against the correct host name
 %% (otherwise the IP will be used, which is almost certainly
@@ -278,7 +278,7 @@ get_tcp_mod(_)                -> gen_tcp.
 insert_server_name_indication(SslOpts, Host) ->
   case proplists:get_value(verify, SslOpts) of
     verify_peer ->
-      [{server_name_indication, Host}|SslOpts];
+      [{server_name_indication, Host} | SslOpts];
     _ ->
       SslOpts
   end.

--- a/test/kpro_test_lib.erl
+++ b/test/kpro_test_lib.erl
@@ -230,6 +230,7 @@ default_ssl_options() ->
   [ {cacertfile, Fname("ca.crt")}
   , {keyfile,    Fname("client.key")}
   , {certfile,   Fname("client.crt")}
+  , {verify, verify_peer}
   ].
 
 osenv(Name) ->


### PR DESCRIPTION
From OTP 20.x, when upgrading a socket to ssl and using {verify_peer,
true}, {server_name_indication, _} must also be specified. Otherwise,
the peer will be verified against the IP of the host and not the
hostname.