### PR TITLE
Discard replica_not_avaliable error code in partition metadata

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -56,6 +56,8 @@
   - Add `{server_name_indication, Host}` when `{verify, verify_peer}` is
     used. This is necessary for OTP >= 20.x.
 * 2.2.6
-  - change kpro_lib:data_size/1 to iolist_size nif
+  - Change kpro_lib:data_size/1 to iolist_size nif
 * 2.2.7
-  - improve varint encoding performance
+  - Improve varint encoding performance
+* 2.2.8
+  - Discard replica_not_available (ReplicaNotAvailable) in partition metadata

--- a/src/kafka_protocol.app.src
+++ b/src/kafka_protocol.app.src
@@ -1,6 +1,6 @@
 {application,kafka_protocol,
              [{description,"Kafka protocol library for Erlang/Elixir"},
-              {vsn,"2.2.7"},
+              {vsn,"2.2.8"},
               {registered,[]},
               {applications,[kernel,stdlib,ssl,snappyer,crc32cer]},
               {env,[]},

--- a/src/kpro_brokers.erl
+++ b/src/kpro_brokers.erl
@@ -168,7 +168,8 @@ discover_partition_leader(Connection, Topic, Partition, Timeout) ->
       end
     , fun({Brokers, PartitionMeta}) ->
           ErrorCode = kpro:find(error_code, PartitionMeta),
-          case ErrorCode =:= ?no_error of
+          case ErrorCode =:= ?no_error orelse
+               ErrorCode =:= ?replica_not_available of
             true  -> {ok, {Brokers, PartitionMeta}};
             false -> {error, ErrorCode}
           end


### PR DESCRIPTION
The cause of this error code is unknow. Usually when replicas
are offline (not available), the metadata response should give
a incomplete `isr` array, and for metadata request version 5 or
higher, it should also give a non-empty arrray for `offline_replicas`.

In some unusual cases, kafka may give a `replica_not_avaliable`
error code (per partition).

This error code is discarded hoping the metadata is sane for
partition leader discovery. Worst case scenario, the subsequent
requests may get sent to a non-leader broker and lead to a
`not_partition_leader` error, but that's a usual error code
the clients have to handle every now and then.