### PR TITLE
Fix field_value() type definition

### DIFF
--- a/src/kpro.erl
+++ b/src/kpro.erl
@@ -185,7 +185,7 @@
 -type required_acks() :: -1..1 | all_isr | none | leader_only.
 -type primitive() :: integer() | string() | binary() | atom().
 -type field_name() :: atom().
--type field_value() :: primitive() | struct() | [struct()].
+-type field_value() :: primitive() | [primitive()] | struct() | [struct()].
 -type struct() :: #{field_name() => field_value()}
                 | [{field_name(), field_value()}].
 -type api() :: atom().


### PR DESCRIPTION
The field value can be a list of `binary()`.

https://github.com/klarna/kafka_protocol/blob/master/src/kpro_schema.erl#L256