### PR TITLE
add lz4 support for api version > 1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,6 @@
 {deps, [{snappyer, "1.2.8"},
-        {crc32cer, "0.1.8"}
+        {crc32cer, "0.1.8"},
+        {lz4b, "0.0.4"}
         ]}.
 
 {erl_opts, [ error
@@ -18,5 +19,3 @@
 {xref_checks, [undefined_function_calls, undefined_functions,
                locals_not_used, deprecated_function_calls,
                deprecated_functions]}.
-
-

--- a/src/kpro_compress.erl
+++ b/src/kpro_compress.erl
@@ -40,13 +40,15 @@ method_to_codec(?no_compression) -> ?KPRO_COMPRESS_NONE.
 -spec compress(kpro:compress_option(), iodata()) -> iodata().
 compress(?no_compression, IoData) -> IoData;
 compress(?gzip, IoData)           -> zlib:gzip(IoData);
-compress(?snappy, IoData)         -> snappy_compress(IoData).
+compress(?snappy, IoData)         -> snappy_compress(IoData);
+compress(?lz4, IoData)            -> lz4_compress(IoData).
 
 %% @doc Decompress batch.
 -spec decompress(kpro:compress_option(), binary()) -> binary().
 decompress(?no_compression, Bin) -> Bin;
 decompress(?gzip, Bin)           -> zlib:gunzip(Bin);
-decompress(?snappy, Bin)         -> java_snappy_unpack(Bin).
+decompress(?snappy, Bin)         -> java_snappy_unpack(Bin);
+decompress(?lz4, Bin)            -> lz4_decompress(Bin).
 
 %%%_* Internals ================================================================
 
@@ -79,6 +81,16 @@ snappy_decompress(BinData) ->
 snappy_compress(IoData) ->
   {ok, Compressed} = snappyer:compress(IoData),
   Compressed.
+
+lz4_compress(IoList) when is_list(IoList) ->
+  lz4_compress(iolist_to_binary(IoList));
+lz4_compress(Bin) ->
+  {ok, Compressed} = lz4b_frame:compress(Bin),
+  Compressed.
+
+lz4_decompress(Bin) ->
+  {ok, Data} = lz4b_frame:decompress(Bin),
+  Data.
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:

--- a/test/kpro_fetch_tests.erl
+++ b/test/kpro_fetch_tests.erl
@@ -181,25 +181,25 @@ with_vsn_topic(Vsn, Topic) ->
     random_config(),
     Topic,
     fun(Connection) ->
-        {BaseOffset, Messages} = produce_randomly(Connection, Topic),
+        {BaseOffset, Messages} = produce_randomly(Vsn, Connection, Topic),
         fetch_and_verify(Connection, Topic, Vsn, BaseOffset, Messages)
     end).
 
-produce_randomly(Connection, Topic) ->
-  produce_randomly(Connection, Topic, rand_num(?RAND_PRODUCE_BATCH_COUNT), []).
+produce_randomly(TestVsn, Connection, Topic) ->
+  produce_randomly(TestVsn, Connection, Topic, rand_num(?RAND_PRODUCE_BATCH_COUNT), []).
 
-produce_randomly(_Connection, _Topic, 0, Acc0) ->
+produce_randomly(_TestVsn, _Connection, _Topic, 0, Acc0) ->
   [{BaseOffset, _, _, _} | _] = Acc = lists:reverse(Acc0),
   {BaseOffset, lists:append([lists:map(fun(M) -> {Vsn, LAT, M} end, Msg)
                              || {_, Vsn, LAT, Msg} <- Acc])};
-produce_randomly(Connection, Topic, Count, Acc) ->
+produce_randomly(TestVsn, Connection, Topic, Count, Acc) ->
   {ok, Versions} = kpro:get_api_versions(Connection),
   {MinVsn, MaxVsn} = maps:get(produce, Versions),
   Vsn = case MinVsn =:= MaxVsn of
           true -> MinVsn;
           false -> MinVsn + rand_num(MaxVsn - MinVsn) - 1
         end,
-  Opts = rand_produce_opts(),
+  Opts = rand_produce_opts(Vsn, TestVsn),
   Batch = make_random_batch(rand_num(?RAND_BATCH_SIZE)),
   Req = kpro_req_lib:produce(Vsn, Topic, ?PARTI, Batch, Opts),
   {ok, Rsp0} = kpro:request_sync(Connection, Req, ?TIMEOUT),
@@ -207,10 +207,16 @@ produce_randomly(Connection, Topic, Count, Acc) ->
    , base_offset := Offset
    } = Rsp = kpro_test_lib:parse_rsp(Rsp0),
   LogAppendTime = maps:get(log_append_time, Rsp, undefined),
-  produce_randomly(Connection, Topic, Count - 1, [{Offset, Vsn, LogAppendTime, Batch} | Acc]).
+  produce_randomly(TestVsn, Connection, Topic, Count - 1, [{Offset, Vsn, LogAppendTime, Batch} | Acc]).
 
-rand_produce_opts() ->
-  #{ compression => rand_element([no_compression, gzip, snappy])
+rand_produce_opts(ProduceVsn, FetchVsn) ->
+  Common = [no_compression, gzip, snappy],
+  #{ compression => rand_element(case ProduceVsn < 2 orelse FetchVsn < 2 of
+                                   %% avoid test old api with lz4
+                                   %% for more check KIP-57 - Interoperable LZ4 Framing
+                                   true -> Common;
+                                   false -> [lz4 | Common]
+                                 end)
    , required_acks => rand_element([leader_only, all_isr, 1, -1])
    }.
 


### PR DESCRIPTION
Init version that support lz4 compression and decompression.
Due to a bug in old kafka version with api version 0 and version1, the lz4 frame header checksum is wrongly computed. As suggest in "KIP-57 - Interoperable LZ4 Framing", it is not necessary to support api version 0 and version 1 in brod.

Producing might work with api v0 and v1, consuming(decompression) with v0 and v1 api will fail with error:

> {error,'ERROR_headerChecksum_invalid'} 


