### PR TITLE
Make send_error reason more informative

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -65,3 +65,5 @@
   - Allo atom as hostname because `inet:hostname() :: atom() | string().`
 * 2.3.0
   - Honor LogAppendTime when decoding messages
+* 2.3.1
+  - Made send_error Reason more informative


### PR DESCRIPTION
The caller actually has all the info, but maybe just lazy only logging the error reason like `connection_down` which is not really useful.
