### PR TITLE
Do not reuse the same timeout during connection timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ erl_crash.dump
 rebar.lock
 .gradle/
 *.log
+*.iml
+.idea/*

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ which is generated from `priv/kafka.bnf`.
 The root level `schema` is always a `struct`.
 A `struct` consists of fields having lower level (maybe nested) `schema`
 
-Struct fileds are documented in `priv/kafka.bnf` as comments,
+Struct fields are documented in `priv/kafka.bnf` as comments,
 but the comments are not generated as Erlang comments in `kpro_schema.erl`
 
 Take `produce` API for example

--- a/src/kpro_brokers.erl
+++ b/src/kpro_brokers.erl
@@ -185,7 +185,7 @@ discover_partition_leader(Connection, Topic, Partition, Timeout) ->
           {ok, {Host, Port}}
       end
     ],
-  kpro_lib:ok_pipe(FL).
+  kpro_lib:ok_pipe(FL, Timeout).
 
 %% @doc Discover group or transactional coordinator.
 -spec discover_coordinator(connection(), coordinator_type(),

--- a/src/kpro_lib.erl
+++ b/src/kpro_lib.erl
@@ -91,16 +91,16 @@ send_and_recv(#kpro_req{api = API, vsn = Vsn} = Req,
   end.
 
 %% @doc Function pipeline.
-%% The first function takes no args, all succeeding ones shoud be arity-0 or 1
+%% The first function takes no args, all succeeding ones should be arity-0 or 1
 %% functions. All functions should retrun
 %% `ok' | `{ok, Result}' | `{error, Reason}'.
 %% where `Result' is the input arg of the next function,
 %% or the result of pipeline if it's the last pipe node.
 %%
-%% NOTE: If a funcition returns `ok' the next should be an arity-0 function.
+%% NOTE: If a function returns `ok' the next should be an arity-0 function.
 %%       Any `{error, Reason}' return value would cause the pipeline to abort.
 %%
-%% NOTE: The pipe funcions are delegated to an agent process to evaluate,
+%% NOTE: The pipe functions are delegated to an agent process to evaluate,
 %%       only exceptions and process links are propagated back to caller
 %%       other side-effects like monitor references are not handled.
 ok_pipe(FunList, Timeout) ->


### PR DESCRIPTION
Hi,

This PR tries to address two points:
* kpro_connection:start/3 spawns a new process which calls init/4. This fun was using the same connection_timeout during different phases of establishing the connection. 
This PR tries to use the "remaining timeout" in the different phases.
* kpro_brokers:discover_partition_leader/4 was calling kpro_lib:ok_pipe/1 without a timeout. It is true that now there is only one function that does network calls, kpro_connection:request_sync/3 but better be safe.

Please let me know if I missed something!