### PR TITLE
Add describe_configs and alter_configs to API

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
+* 2.4.0
+  - Add Describe and Alter Configs APIs, part of KIP-133
+
 * 2.3.6
-   - Upgrade snappyer and crc32cer to fix build in windows
+  - Upgrade snappyer and crc32cer to fix build in windows
 
 * 2.3.5
   - Improve produce request encoding performance by 35%

--- a/src/kpro_req_lib.erl
+++ b/src/kpro_req_lib.erl
@@ -43,6 +43,10 @@
         , delete_topics/3
         ]).
 
+-export([ describe_configs/3
+        , alter_configs/3
+        ]).
+
 -export([ encode/3
         , make/3
         ]).
@@ -285,7 +289,7 @@ add_offsets_to_txn(TxnCtx, CgId) ->
 %% @doc Make `create_topics' request.
 %% if 0 is given as `timeout' option the request will trigger a creation
 %% but return immediately.
-%% `validate_only' option is only relavent when the API version is
+%% `validate_only' option is only relevant when the API version is
 %% greater than 0.
 -spec create_topics(vsn(), [Topics :: kpro:struct()],
                     #{timeout => kpro:int32(),
@@ -320,6 +324,28 @@ delete_topics(Vsn, Topics, Opts) ->
           , timeout => Timeout
           },
   make(delete_topics, Vsn, Body).
+
+%% @doc Make a `describe_configs' request.
+%% `include_synonyms' option is only relevant when the API version is
+%% greater than 0.
+-spec describe_configs(vsn(), [Resources :: kpro:struct()],
+                       #{include_synonyms => boolean()}) -> req().
+describe_configs(Vsn, Resources, Opts) ->
+  IncludeSynonyms = maps:get(include_synonyms, Opts, false),
+  Body = #{ resources => Resources
+          , include_synonyms => IncludeSynonyms
+          },
+  make(describe_configs, Vsn, Body).
+
+%% @doc Make an `alter_configs' request.
+-spec alter_configs(vsn(), [Resources :: kpro:struct()],
+                    #{validate_only => boolean()}) -> req().
+alter_configs(Vsn, Resources, Opts) ->
+  ValidateOnly = maps:get(validate_only, Opts, false),
+  Body = #{ resources => Resources
+          , validate_only => ValidateOnly
+          },
+  make(alter_configs, Vsn, Body).
 
 %% @doc Help function to make a request body.
 -spec make(api(), vsn(), struct()) -> req().

--- a/test/kpro_test_lib.erl
+++ b/test/kpro_test_lib.erl
@@ -180,6 +180,16 @@ parse_rsp(#kpro_rsp{ api = create_partitions
                    , msg = Msg
                    }) ->
   error_if_any(kpro:find(topic_errors, Msg));
+parse_rsp(#kpro_rsp{ api = describe_configs
+                   , msg = Msg
+                   }) ->
+  Resources = kpro:find(resources, Msg),
+  ok = error_if_any(Resources),
+  Resources;
+parse_rsp(#kpro_rsp{ api = alter_configs
+                   , msg = Msg
+                   }) ->
+  error_if_any(kpro:find(resources, Msg));
 parse_rsp(#kpro_rsp{msg = Msg}) ->
   Msg.
 


### PR DESCRIPTION
With `describe_configs` its possible to tell how a topic is configured
including defaults and overrides, and with `alter_configs` the configs
can be changed.

This would handle the protocol parts of klarna/brod#387

The messages became available in KAFKA_VERSION=0.11 as part of KIP-133
See also KIP-569: DescribeConfigsResponse