### PR TITLE
Remove call to crypto:hmac function on OTP23+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,8 @@ jobs:
 
     # Compile
     - name: Compile
-      run: rebar3 do compile, dialyzer, #edoc , xref Temorary workaround, see #3, #4
+      run: |
+        rebar3 do compile, dialyzer, edoc, xref
 
     # Tests
     - name: Run tests


### PR DESCRIPTION
Fixes #3 in a rather ugly way.