### PR TITLE
Adjust hostname typespec

### DIFF
--- a/src/kpro.erl
+++ b/src/kpro.erl
@@ -151,7 +151,7 @@
 -type magic() :: 0..2.
 
 -type client_id() :: binary().
--type hostname() :: binary() | inet:hostname().
+-type hostname() :: binary() | inet:hostname() | inet:ip_address().
 -type portnum() :: non_neg_integer().
 -type endpoint() :: {hostname(), portnum()}.
 -type corr_id() :: int32().


### PR DESCRIPTION
Maybe I'm wrong, but I think ip addresses are allowed as well here. I tried to use an ip tuple and it went alright, but maybe I didn't went through all the flows. 

Also, why `binary() | inet:hostname()`? inet:hostname includes string(), which probably includes all relevant binaries?