### PR TITLE
fix application behaviour hurting OTP's "release_handler"

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+* 4.0.4
+   - The application ˋstartˋ method must return the `pid` of the top supervisor
 * 4.0.3
    - Fix type spec for `hostname()` to include `inet:ip_address()`
 * 4.0.2

--- a/src/kpro_app.erl
+++ b/src/kpro_app.erl
@@ -11,6 +11,6 @@
 start(_StartType, _StartArgs) ->
     Provides = application:get_env(kafka_protocol, provide_compression, []),
     kpro:provide_compression(Provides),
-    {ok, self()}.
+    kpro_sup:start_link().
 
 stop(_State) -> ok.

--- a/src/kpro_sup.erl
+++ b/src/kpro_sup.erl
@@ -4,7 +4,7 @@
 
 -export([start_link/0, init/1]).
 
-start_link() -> supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+start_link() -> supervisor:start_link(?MODULE, []).
 
 %% @doc Supervisor behaviour callback
 init([]) ->

--- a/src/kpro_sup.erl
+++ b/src/kpro_sup.erl
@@ -1,0 +1,13 @@
+-module(kpro_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0, init/1]).
+
+start_link() -> supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% @doc Supervisor behaviour callback
+init([]) ->
+    {ok, {
+        #{strategy => one_for_one, intensity => 10, period => 5}, []}
+    }.


### PR DESCRIPTION
Hi, 

Many thanks for your open source.
We just noticed that your application breaks the "release_handler" of OTP.

The child <0.9438.0> of the application_master's child is not a supervisor process.

```erl
application_controller:get_master(kafka_protocol).
<0.11604.0>

application_master:get_child(<0.11604.0>).        
{<0.9438.0>,kpro_app}

sys:get_state(<0.9438.0>).
** exception exit: {timeout,{sys,get_state,[<0.9438.0>]}}
     in function  sys:send_system_msg/2 (sys.erl, line 338)
     in call from sys:get_state/1 (sys.erl, line 139)
```

Thus any release upgrade breaks too :

```erl
release_handler:install_release("1.161.0").      
{error,{'EXIT',{timeout,{sys,get_status,[<0.9438.0>]}}}}
```

2022-04-12 15:15:47.788919-04:00 [error] <0.131.0> release_handler: cannot find top supervisor for application kafka_protocol

Best regards,
Frank