### PR TITLE
Add kpro_auth_backend:auth/8 to support passing handshake vsn

### DIFF
--- a/src/kpro_auth_backend.erl
+++ b/src/kpro_auth_backend.erl
@@ -16,12 +16,18 @@
 
 -module(kpro_auth_backend).
 
--export([auth/7]).
+-export([auth/8]).
 
 -callback auth(Host :: string(), Sock :: gen_tcp:socket() | ssl:sslsocket(),
                Mod :: gen_tcp | ssl, ClientName :: binary(),
                Timeout :: pos_integer(), SaslOpts :: term()) ->
                  ok | {error, Reason :: term()}.
+
+-callback auth(Host :: string(), Sock :: gen_tcp:socket() | ssl:sslsocket(),
+               HandShakeVsn :: non_neg_integer(), Mod :: gen_tcp | ssl, ClientName :: binary(),
+               Timeout :: pos_integer(), SaslOpts :: term()) ->
+                 ok | {error, Reason :: term()}.
+
 
 -spec auth(CallbackModule :: atom(), Host :: string(),
            Sock :: gen_tcp:socket() | ssl:sslsocket(),
@@ -30,6 +36,27 @@
             ok | {error, Reason :: term()}.
 auth(CallbackModule, Host, Sock, Mod, ClientName, Timeout, SaslOpts) ->
   CallbackModule:auth(Host, Sock, Mod, ClientName, Timeout, SaslOpts).
+
+-spec auth(CallbackModule :: atom(), Host :: string(),
+           Sock :: gen_tcp:socket() | ssl:sslsocket(),
+           HandShakeVsn :: non_neg_integer(),
+           Mod :: gen_tcp | ssl, ClientName :: binary(),
+           Timeout :: pos_integer(), SaslOpts :: term()) ->
+            ok | {error, Reason :: term()}.
+auth(CallbackModule, Host, Sock, Vsn, Mod, ClientName, Timeout, SaslOpts) ->
+    case is_exported(CallbackModule, auth, 7) of
+        true ->
+            CallbackModule:auth(Host, Sock, Mod, Vsn, ClientName, Timeout, SaslOpts);
+        false ->
+            auth(CallbackModule, Host, Sock, Mod, ClientName, Timeout, SaslOpts)
+    end.
+
+is_exported(M, F, A) ->
+  case erlang:module_loaded(M) of
+    false -> code:ensure_loaded(M);
+    true -> ok
+  end,
+  erlang:function_exported(M, F, A).
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:

--- a/src/kpro_auth_backend.erl
+++ b/src/kpro_auth_backend.erl
@@ -28,6 +28,7 @@
                Timeout :: pos_integer(), SaslOpts :: term()) ->
                  ok | {error, Reason :: term()}.
 
+-optional_callbacks([auth/6]).
 
 -spec auth(CallbackModule :: atom(), Host :: string(),
            Sock :: gen_tcp:socket() | ssl:sslsocket(),

--- a/src/kpro_auth_backend.erl
+++ b/src/kpro_auth_backend.erl
@@ -46,7 +46,7 @@ auth(CallbackModule, Host, Sock, Mod, ClientName, Timeout, SaslOpts) ->
 auth(CallbackModule, Host, Sock, Vsn, Mod, ClientName, Timeout, SaslOpts) ->
     case is_exported(CallbackModule, auth, 7) of
         true ->
-            CallbackModule:auth(Host, Sock, Mod, Vsn, ClientName, Timeout, SaslOpts);
+            CallbackModule:auth(Host, Sock, Vsn, Mod, ClientName, Timeout, SaslOpts);
         false ->
             auth(CallbackModule, Host, Sock, Mod, ClientName, Timeout, SaslOpts)
     end.

--- a/src/kpro_sasl.erl
+++ b/src/kpro_sasl.erl
@@ -35,7 +35,7 @@ auth(_Host, _Sock, _Mod, _ClientId, _Timeout, ?undef, _Vsn) ->
   ok;
 auth(Host, Sock, Mod, ClientId, Timeout,
      {callback, ModuleName, Opts}, Vsn) ->
-  case kpro_auth_backend:auth(ModuleName, Vsn, Host, Sock, Mod,
+  case kpro_auth_backend:auth(ModuleName, Host, Sock, Vsn, Mod,
                               ClientId, Timeout, Opts) of
     ok ->
       ok;

--- a/src/kpro_sasl.erl
+++ b/src/kpro_sasl.erl
@@ -34,8 +34,8 @@ auth(_Host, _Sock, _Mod, _ClientId, _Timeout, ?undef, _Vsn) ->
   %% no auth
   ok;
 auth(Host, Sock, Mod, ClientId, Timeout,
-     {callback, ModuleName, Opts}, _Vsn) ->
-  case kpro_auth_backend:auth(ModuleName, Host, Sock, Mod,
+     {callback, ModuleName, Opts}, Vsn) ->
+  case kpro_auth_backend:auth(ModuleName, Vsn, Host, Sock, Mod,
                               ClientId, Timeout, Opts) of
     ok ->
       ok;


### PR DESCRIPTION
This PR changes `kpro_auth_backend` to export `auth/8`  vs `auth/7` to support passing the handshake version to a callback module.  `auth/8` will check to see `CallbackModule` exports `auth/7`, if it does not `auth/6` on the callback module will be called for backwards compat.

As for the placement of the handshake vsn arg in function head, no strong feelings. I would even go so far as to suggest passing a map or a record to the callback module, but that doesn't have to be done in this PR either, unless we're open to the idea and would like to avoid future churn. An example of what the might look like can be seen here : `https://github.com/kafka4beam/brod_gssapi/blob/51be03dcbcaa48cd77edcda3e8e75ca5e20123e8/src/brod_gssapi.erl#L94`. However, we'd want to support a `private` key where callback modules can stuff in k/vs relevant to their context. 

