### PR TITLE
fix: handle nested wrapped secrets

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+* 4.1.2
+  - Allow passwords passed down to `kpro_connection` to be multiply
+    nested functions, instead of considering at most a single layer.
+
 * 4.1.1
    - Ported changes from EMQX's fork (based on 2.3.6) back to master branch
      - Included an pushback twards 'no_ack' callers. https://github.com/emqx/kafka_protocol/pull/1

--- a/src/kpro_connection.erl
+++ b/src/kpro_connection.erl
@@ -598,10 +598,7 @@ hint_msg(_, _, _) ->
 get_sasl_opt(Config) ->
   case maps:get(sasl, Config, ?undef) of
     {Mechanism, User, Pass0} when ?IS_PLAIN_OR_SCRAM(Mechanism) ->
-      Pass = case is_function(Pass0) of
-               true  -> Pass0();
-               false -> Pass0
-             end,
+      Pass = unwrap_pass(Pass0),
       {Mechanism, User, Pass};
     {Mechanism, File} when ?IS_PLAIN_OR_SCRAM(Mechanism) ->
       {User, Pass} = read_sasl_file(File),
@@ -609,6 +606,11 @@ get_sasl_opt(Config) ->
     Other ->
       Other
   end.
+
+unwrap_pass(Fun) when is_function(Fun) ->
+  unwrap_pass(Fun());
+unwrap_pass(Pass) ->
+  Pass.
 
 %% Read a regular file, assume it has two lines:
 %% First line is the sasl-plain username


### PR DESCRIPTION
Some applications might already give wrapped secrets to `kpro`.  In that case, we can just keep peeling off the layers until we get to the secret.