### PR TITLE
Support sasl reauthentication

### DIFF
--- a/src/kpro_connection.erl
+++ b/src/kpro_connection.erl
@@ -498,8 +498,12 @@ format_status(Opt, Status) ->
 
 print_msg(Device, {_From, {send, Request}}, State) ->
   do_print_msg(Device, "send: ~p", [Request], State);
+print_msg(Device, {_From, {get_api_vsns, Request}}, State) ->
+  do_print_msg(Device, "get_api_vsns", [Request], State);
 print_msg(Device, {tcp, _Sock, Bin}, State) ->
   do_print_msg(Device, "tcp: ~p", [Bin], State);
+print_msg(Device, {ssl, _Sock, Bin}, State) ->
+  do_print_msg(Device, "ssl: ~p", [Bin], State);
 print_msg(Device, {tcp_closed, _Sock}, State) ->
   do_print_msg(Device, "tcp_closed", [], State);
 print_msg(Device, {tcp_error, _Sock, Reason}, State) ->

--- a/test/kpro_connection_tests.erl
+++ b/test/kpro_connection_tests.erl
@@ -73,6 +73,21 @@ extra_sock_opts_test() ->
   ?assertEqual(true, proplists:get_value(delay_send, InetSockOpts)),
   ok = kpro_connection:stop(Pid).
 
+sasl_reauthenticate_after_test() ->
+  Config0 = kpro_test_lib:connection_config(ssl),
+  case kpro_test_lib:get_kafka_version() of
+    ?KAFKA_0_9 ->
+      ok;
+    ?KAFKA_0_10 ->
+      {ok, Pid} = connect(Config0#{sasl => kpro_test_lib:sasl_config(file)}),
+      ok = kpro_connection:sasl_reauthenticate_after(Pid, 1000),
+      ok = kpro_connection:stop(Pid);
+    _ ->
+      {ok, Pid} = connect(Config0#{sasl => kpro_test_lib:sasl_config(file)}),
+      ok = kpro_connection:sasl_reauthenticate_after(Pid, 1000),
+      ok = kpro_connection:stop(Pid)
+  end.
+
 connect(Config) ->
   Protocol = kpro_test_lib:guess_protocol(Config),
   [{Host, Port} | _] = kpro_test_lib:get_endpoints(Protocol),


### PR DESCRIPTION
Settle pending requests and re-invoke SASL authentication.

References
* [session lifetime check in Kafka JS](https://github.com/tulios/kafkajs/blob/55b0b416308b9e597a5a6b97b0a6fd6b846255dc/src/network/connection.js#L310)
* [blocking re-authentication in Kafka
  JS](https://github.com/tulios/kafkajs/blob/55b0b416308b9e597a5a6b97b0a6fd6b846255dc/src/network/connection.js#L381)