### PR TITLE
Doc generated with ex doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     # Compile
     - name: Compile
       run: |
-        rebar3 do compile, dialyzer, edoc, xref
+        rebar3 do compile, dialyzer, ex_doc, xref
 
     # Tests
     - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ rebar.lock
 *.log
 *.iml
 .idea/*
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ edoc: profile=edown
 edoc:
 	@$(rebar_cmd) edoc
 
+.PHONY: ex_doc
+ex_doc:
+	@$(rebar_cmd) ex_doc
+
 .PHONY: dialyze
 dialyze: compile
 	@$(rebar_cmd) dialyzer

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To test with an existing kafka cluster set below environment variables:
 - `KPRO_TEST_KAFKA_TOPIC_NAME`: Topic name for message produce/fetch test.
 - `KPRO_TEST_KAFKA_TOPIC_LAT_NAME`: Topic name for message produce/fetch test with `message.timestamp.type=LogAppendTime` set.
 - `KPRO_TEST_KAFKA_SASL_USER_PASS_FILE`: A text file having two lines for username and password.
-- `KPRO_TEST_SSL_TRUE`: Set to 'TRUE' or 'true' or '1' to use `ssl => true' in connection config (if kafka ca is trusted already)
+- `KPRO_TEST_SSL_TRUE`: Set to `TRUE` or `true` or '1' to use `ssl => true` in connection config (if kafka ca is trusted already)
 - `KPRO_TEST_SSL_CA_CERT_FILE`: Ca cert file
 - `KPRO_TEST_SSL_KEY_FILE`: Client private key file
 - `KPRO_TEST_SSL_CERT_FILE`: Client cert file

--- a/rebar.config
+++ b/rebar.config
@@ -42,6 +42,7 @@
           {"NOTICE", #{title => "Notice"}}
     ]},
     {main, "README.md"},
+    {homepage_url, "https://hexdocs.pm/kafka_protocol"},
     {source_url, "https://github.com/kafka4beam/kafka_protocol"},
     {api_reference, false}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -27,3 +27,21 @@
 {xref_checks, [undefined_function_calls, undefined_functions,
                locals_not_used, deprecated_function_calls,
                deprecated_functions]}.
+
+{project_plugins, [rebar3_hex, rebar3_ex_doc]}.
+
+{hex, [
+    {doc, #{provider => ex_doc}}
+]}.
+
+{ex_doc, [
+    {extras, [
+          {"README.md", #{title => "Overview"}},
+          {"changelog.md", #{title => "ChangeLog"}},
+          {"LICENSE", #{title => "License"}},
+          {"NOTICE", #{title => "Notice"}}
+    ]},
+    {main, "README.md"},
+    {source_url, "https://github.com/kafka4beam/kafka_protocol"},
+    {api_reference, true}
+]}.

--- a/rebar.config
+++ b/rebar.config
@@ -36,12 +36,12 @@
 
 {ex_doc, [
     {extras, [
-          {"README.md", #{title => "Overview"}},
           {"changelog.md", #{title => "ChangeLog"}},
+          {"README.md", #{title => "Overview"}},
           {"LICENSE", #{title => "License"}},
           {"NOTICE", #{title => "Notice"}}
     ]},
     {main, "README.md"},
     {source_url, "https://github.com/kafka4beam/kafka_protocol"},
-    {api_reference, true}
+    {api_reference, false}
 ]}.

--- a/src/kpro.erl
+++ b/src/kpro.erl
@@ -360,7 +360,7 @@ connect(Endpoint, ConnConfig) ->
 connect_any(Endpoints, ConnConfig) ->
   kpro_brokers:connect_any(Endpoints, ConnConfig).
 
-%% @doc Sotp connection process.
+%% @doc Stop connection process.
 -spec close_connection(connection()) -> ok.
 close_connection(Connection) ->
   kpro_connection:stop(Connection).


### PR DESCRIPTION
- for issue https://github.com/kafka4beam/kafka_protocol/issues/107 
- to generate doc use `make ex_doc` 
- there are 2 warnings to `type references type "kpro_sent_reqs:requests/0" but it is hidden or private`
