### PR TITLE
fix: socket write error should not result in a crash report

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+* 4.1.8
+  - Avoid generating crash-report when failed to write socket [PR#124](https://github.com/kafka4beam/kafka_protocol/pull/124)
+
 * 4.1.7
   - Automatically re-authenticate before session lifetime expires if SASL
     authentication module returns `{ok, ServerResponse}` and ServerResponse

--- a/src/kpro_connection.erl
+++ b/src/kpro_connection.erl
@@ -483,7 +483,7 @@ send_request({From, {send, Request}},
                , {caller, Caller}
                , {reason, Reason0}
                ],
-      exit({send_error, Reason})
+      exit({shutdown, Reason})
   end,
   State#state{requests = NewRequests}.
 


### PR DESCRIPTION
When socket is closed writing data to it would result in a `einval` error.
In this case the `tcp_closed` and `ssl_closed` message are likely already in the mailbox,
this should not result in a crash report, so change it to a `{shutdown, _}` reason instead.

e.g. from `proc_lib:crash_report/4`:

```
error_logger: {"type":"crash_report","tag":"error_report"}, logger_formatter: {"title":"CRASH REPORT"}, msg: crasher: initial call: kpro_connection:init/4, pid: <0.12144989.0>, registered_name: [], exit: {{send_error,[{api,produce},{vsn,7},{caller,<0.1983516.0>},{reason,einval}]}
```