### PR TITLE
fix: update actions/cache to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,14 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Cache Hex packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/rebar3/hex/hexpm/packages
         key: ${{ runner.os }}-hex2-${{ hashFiles(format('{0}{1}', github.workspace, '/rebar.lock')) }}
         restore-keys: |
           ${{ runner.os }}-hex2-
     - name: Cache Dialyzer PLTs
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/rebar3/rebar3_*_plt
         key: ${{ runner.os }}--dialyzer2-${{ hashFiles(format('{0}{1}', github.workspace, '/rebar.config')) }}


### PR DESCRIPTION
Pipeline jobs in https://github.com/kafka4beam/kafka_protocol/pull/129 fail because `actions/cache@v2` is deprecated, so updated it to `v4`.

Error message:
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
```