### PR TITLE
250403 upgrade to `crc32cer-1.0.1`

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{deps, [{crc32cer, "0.1.12"}]}.
+{deps, [{crc32cer, "1.0.1"}]}.
 
 {profiles,
   [ { test,


### PR DESCRIPTION
1. Upgrade to `crc32cer-1.0.1` for performance improvement on arm. (previously upgraded performance improvement for x86, see #132 )
2. The new version introduced a `nif_d` API so to get scheduled on dirty-scheduler
3. Make binary message batch to help:
  - `crc32cer` nif code do not have to inspect iolist as binary
  - When batch size is large, the message sent to `kpro_conn` process is more compacted (one large binary vs long list of small binaries)