### PR TITLE
build: bump crc32cer from 1.0.3 to 1.0.4 for link error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
-* 4.2.7
+* 4.2.8
+  - Upgrade crc32cer from 1.0.4 to 1.0.4 for link error.
 
+* 4.2.7
   - Upgrade crc32cer from 1.0.2 to 1.0.3 for better build speed.
     The new version avoids clone some unnecessary submodules.
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{deps, [{crc32cer, "1.0.3"}]}.
+{deps, [{crc32cer, "1.0.4"}]}.
 
 {profiles,
   [ { test,


### PR DESCRIPTION
fix link error

```
/usr/bin/ld: external/src/google-crc32c-build/libcrc32c.a(crc32c.cc.o): relocation R_X86_64_32 against `.bss' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld:
external/src/google-crc32c-build/libcrc32c.a(crc32c_sse42.cc.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld:
external/src/google-crc32c-build/libcrc32c.a(crc32c_portable.cc.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPI
```