### PR TITLE
WIP: handle (e)zstd decompression when content size is unknown (0)

### DIFF
--- a/src/kpro_compress.erl
+++ b/src/kpro_compress.erl
@@ -91,6 +91,13 @@ do_compress(Name, IoData) ->
     Data = maybe_convert_iodata_to_binary(Module, IoData),
     iodata(Module:compress(Data)).
 
+%% EZSTD doesn't handle unknown content size in decompress/1.
+do_decompress(?zstd, <<_:32, 0, _/binary>> = Bin) ->
+    Module = get_module(?zstd, ezstd),
+    Ctx = Module:create_decompression_context(4096),
+    IoData = iodata(Module:decompress_streaming(Ctx, Bin)),
+    iolist_to_binary(IoData);
+
 do_decompress(Name, Bin) ->
     Module = get_module(Name),
     iodata(Module:decompress(Bin)).


### PR DESCRIPTION
Hi, thanks for the library.

I've been testing the **zstd** compression codec support in `kafka_protocol` and noticed a `ZSTD_CONTENTSIZE_UNKNOWN` error when trying to _decompress_ a **zstd**-compressed message with "content size" byte as 0.

This happens when producing a message with `kafka-console-producer` with `--compression-codec zstd` option.  
The produced message is successfully consumed by a Java consumer, but fails in Elixir with `kafka_protocol`. 

#### My setup

* `confluentinc/cp-kafka:7.6.1` docker image with ZK
* `:broadway_kafka` v`0.4.4` Elixir  consumer
* `kafka_protocol` v`4.2.8`

#### Working compression codec: `gzip`

Producing a message:
```shell
docker compose exec kafka bash -c 'echo GZIP-compression GZIP | kafka-console-producer --broker-list localhost:9092 --topic sample_topic --compression-codec gzip'
```
The consumer receives and decodes the message just fine.

#### Non-working compression codec: `zstd`

Producing a message:
```shell
docker compose exec kafka bash -c 'echo ZSTD-compression ZSTD | kafka-console-producer --broker-list localhost:9092 --topic sample_topic --compression-codec zstd'
```

The error seen:
```shell
** (stop) "failed to decompress: ZSTD_CONTENTSIZE_UNKNOWN"
    (kafka_protocol 4.2.8) .../project/deps/kafka_protocol/src/kpro_compress.erl:112: :kpro_compress.iodata/1
    (kafka_protocol 4.2.8) .../project/deps/kafka_protocol/src/kpro_batch.erl:199: :kpro_batch.do_decode/2
```

Trace:
```erlang
[error] Consumer <consumer-id> terminate reason: {"failed to decompress: ZSTD_CONTENTSIZE_UNKNOWN",
 [
   {:kpro_compress, :iodata, 1,
    [
      file: ~c".../project/deps/kafka_protocol/src/kpro_compress.erl",
      line: 112
    ]},
   {:kpro_batch, :do_decode, 2,
    [
      file: ~c".../project/deps/kafka_protocol/src/kpro_batch.erl",
      line: 199
    ]},
   {:kpro_batch, :decode, 2,
    [
      file: ~c".../project/deps/kafka_protocol/src/kpro_batch.erl",
      line: 129
    ]},
   {:brod_utils, :parse_fetch_rsp, 1,
    [
      file: ~c".../project/deps/brod/src/brod_utils.erl",
      line: 787
    ]},
   {:brod_utils, :parse_rsp, 1,
    [
      file: ~c".../project/deps/brod/src/brod_utils.erl",
      line: 615
    ]},
   {:brod_consumer, :handle_fetch_response, 2,
    [
      file: ~c".../project/deps/brod/src/brod_consumer.erl",
      line: 510
    ]},
   {:gen_server, :try_handle_info, 3, [file: ~c"gen_server.erl", line: 2173]},
   {:gen_server, :handle_msg, 6, [file: ~c"gen_server.erl", line: 2261]}
 ]}
 ```

#### Proposed fix

Until (and if) the ezstd library is updated to handle this case:

```erlang
do_decompress(?zstd, <<_:32, 0, _/binary>> = Bin) ->
    Module = get_module(?zstd, ezstd),
    Ctx = Module:create_decompression_context(4096),
    IoData = iodata(Module:decompress_streaming(Ctx, Bin)),
    iolist_to_binary(IoData);
```

More info and suggestion for solution by the owner of ezstd in this thread: https://github.com/silviucpp/ezstd/issues/22#issuecomment-3236157887.

#### Questions

I'm not sure what a reasonable _decompression context size_ should be and if it should be configurable. The value `4096` was sufficient for my tests (with bigger messages than in the example).  

Finally, any help would be appreciated to write tests for this case.

If there's any more code, or a sample project you'd like me to provide, please let me know.
