### PR TITLE
refactor: for nonce avoid base64 padding with '='

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+* 4.2.10
+  - Refactor SCRAM nonce for client first message to pick from char-set `a-zA-Z0-9`.
+
 * 4.2.9
   - Improve message encoding performance.
   - Allow `{magic_v2, Size, IoList}` as batch input for `produce` request.

--- a/src/kpro_scram.erl
+++ b/src/kpro_scram.erl
@@ -1,5 +1,6 @@
 %%%
 %%%   Copyright (c) 2018-2021, Klarna Bank AB (publ)
+%%%   Copyright (c) 2022-2025, Kafka4beam
 %%%
 %%%   Licensed under the Apache License, Version 2.0 (the "License");
 %%%   you may not use this file except in compliance with the License.
@@ -41,7 +42,7 @@
 %% @doc Initialize a scram context.
 -spec init(sha256 | sha512, binary(), binary()) -> scram().
 init(Sha, User, Pass) ->
-  Nonce = base64:encode(crypto:strong_rand_bytes(2 * ?MY_NONCE_LEN div 3)),
+  Nonce = nonce(?MY_NONCE_LEN),
   #{ sha => Sha
    , pass => Pass
    , nonce => Nonce
@@ -140,6 +141,18 @@ hmac(Sha, Key, Data) ->
 hmac(Sha, Key, Data) ->
   crypto:hmac(Sha, Key, Data).
 -endif.
+
+nonce(Bytes) ->
+    bin(rand_chars(Bytes)).
+
+rand_chars(0) -> [];
+rand_chars(N) -> [rand_char() | rand_chars(N - 1)].
+
+rand_char() -> base62(rand:uniform(62) - 1).
+
+base62(I) when I < 26 -> $A + I;
+base62(I) when I < 52 -> $a + I - 26;
+base62(I) -> $0 + I - 52.
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:


### PR DESCRIPTION
'=' is technically not forbidden and it worked just fine with Kafka since day 1, but it could potentially become an issue maybe in the future for some other Kafka API compatible server.