### PR TITLE
feat: support process alias as request reference

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+* 4.3.0
+  - Allow process alias as request reference.
+    Previously `kpro_req_lib:produce/5` creates a reference for the caller,
+    now new API `kpro_req_lib:produce/6` can be used with pre-made reference.
+    If the reference is passed as `{alias, Ref}`, the Kafka response is sent to the alias, but not the `kpro:send` caller.
+
 * 4.2.9
   - Improve message encoding performance.
   - Allow `{magic_v2, Size, IoList}` as batch input for `produce` request.

--- a/include/kpro.hrl
+++ b/include/kpro.hrl
@@ -21,7 +21,7 @@
 -include("kpro_error_codes.hrl").
 
 -record(kpro_req,
-        { ref :: reference()
+        { ref :: kpro:req_ref()
         , api :: kpro:api()
         , vsn :: kpro:vsn()
         , no_ack = false :: boolean() %% set to true for fire-n-forget requests
@@ -29,7 +29,7 @@
         }).
 
 -record(kpro_rsp,
-        { ref :: false | reference()
+        { ref :: false | kpro:req_ref()
         , api :: kpro:api()
         , vsn :: kpro:vsn()
         , msg :: binary() | kpro:struct()

--- a/src/kpro.erl
+++ b/src/kpro.erl
@@ -118,6 +118,7 @@
              , producer_id/0
              , protocol/0
              , req/0
+             , req_ref/0
              , required_acks/0
              , rsp/0
              , schema/0
@@ -194,6 +195,7 @@
                 | [{field_name(), field_value()}].
 -type api() :: atom().
 -type req() :: #kpro_req{}.
+-type req_ref() :: reference() | {alias, reference()}.
 -type rsp() :: #kpro_rsp{}.
 -type compress_option() :: ?no_compression
                          | ?gzip

--- a/src/kpro_sent_reqs.erl
+++ b/src/kpro_sent_reqs.erl
@@ -39,7 +39,7 @@
 
 -type corr_id() :: kpro:corr_id().
 -define(REQ(Caller, Ref, API, Vsn, Ts), {Caller, Ref, API, Vsn, Ts}).
--type req() :: ?REQ(pid(), reference(), kpro:api(), kpro:vsn(), integer()).
+-type req() :: ?REQ(pid(), kpro:req_ref(), kpro:api(), kpro:vsn(), integer()).
 
 -record(requests,
         { corr_id = 0
@@ -61,7 +61,7 @@ is_empty(#requests{sent = Sent}) -> maps:size(Sent) == 0.
 
 %% @doc Add a new request to sent collection.
 %% Return the last corrlation ID and the new collection.
--spec add(requests(), pid(), reference(), kpro:api(), kpro:vsn()) ->
+-spec add(requests(), pid(), kpro:req_ref(), kpro:api(), kpro:vsn()) ->
         {corr_id(), requests()}.
 add(#requests{ corr_id = CorrId
              , sent    = Sent
@@ -82,7 +82,7 @@ del(#requests{sent = Sent} = Requests, CorrId) ->
 %% @doc Get caller of a request having the given correlation ID.
 %% Crash if the request is not found.
 -spec get_req(requests(), corr_id()) ->
-        {pid(), reference(), kpro:api(), kpro:vsn()}.
+        {pid(), kpro:req_ref(), kpro:api(), kpro:vsn()}.
 get_req(#requests{sent = Sent}, CorrId) ->
   ?REQ(Caller, Ref, API, Vsn, _Ts) = maps:get(CorrId, Sent),
   {Caller, Ref, API, Vsn}.


### PR DESCRIPTION
Support process alias as request reference so the Kafka reply can be delivered to a different process than the one which created the request.