### PR TITLE
fix(kpro_connection): fix pid leak when init failed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+* 4.3.1
+  - Fix a connection pid leak when init failed.
+    The owner process maybe get an expected 'EXIT' message after `{error, _}` was returned from `kpro_connection:start`.
+
 * 4.3.0
   - Allow process alias as request reference.
     Previously `kpro_req_lib:produce/5` creates a reference for the caller,

--- a/src/kpro_connection.erl
+++ b/src/kpro_connection.erl
@@ -1,4 +1,5 @@
 %%%   Copyright (c) 2014-2021, Klarna Bank AB (publ)
+%%%   Copyright (c) 2021-2025, Kafka4beam
 %%%
 %%%   Licensed under the Apache License, Version 2.0 (the "License");
 %%%   you may not use this file except in compliance with the License.
@@ -209,8 +210,7 @@ init(Parent, Host, Port, Config) ->
         IsSsl = maps:get(ssl, Config, false),
         SaslOpt = get_sasl_opt(Config),
         ok = maybe_log_hint(Host, Port, Reason, IsSsl, SaslOpt),
-        proc_lib:init_ack(Parent, {error, {Reason, Stack}}),
-        erlang:exit(normal)
+        proc_lib:init_fail(Parent, {error, {Reason, Stack}}, {exit, normal})
     end,
   %% From now on, enter `{active, once}' mode
   %% NOTE: ssl doesn't support `{active, N}'

--- a/test/kpro_connection_tests.erl
+++ b/test/kpro_connection_tests.erl
@@ -1,4 +1,5 @@
 %%%   Copyright (c) 2018-2021, Klarna Bank AB (publ)
+%%%   Copyright (c) 2021-2025, Kafka4beam
 %%%
 %%%   Licensed under the Apache License, Version 2.0 (the "License");
 %%%   you may not use this file except in compliance with the License.
@@ -85,6 +86,13 @@ sasl_callback_test() ->
 
       ok = kpro_connection:stop(Pid)
   end.
+
+conn_timeout_test() ->
+  Config = #{connect_timeout => 10},
+  {links, Links0} = erlang:process_info(self(), links),
+  ?assertMatch({error, {timeout, _}}, kpro_connection:start("1.1.1.1", 9092, Config)),
+  {links, Links1} = erlang:process_info(self(), links),
+  ?assertEqual(lists:sort(Links0), lists:sort(Links1)).
 
 no_api_version_query_test() ->
   Config = #{query_api_versions => false},


### PR DESCRIPTION
Previously `proc_lib:init_ack` was called to return init result to caller, the caller gets `{error, Reason}` but the connection process is still linked (although exit immediately).
This causes the caller process to get an unexpected `EXIT` message when trapping exit.