### PR TITLE
chore: pin crc32cer 1.1.3

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{deps, [{crc32cer, "1.1.2"}]}.
+{deps, [{crc32cer, "1.1.3"}]}.
 
 {profiles,
   [ { test,


### PR DESCRIPTION
this version has the externa c source files uploaded to hex so there is no longer build-time git clone